### PR TITLE
Add raygun crashreporting

### DIFF
--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Configuration;
+using Raygun4Maui;
 
 namespace mauitests;
 
@@ -20,7 +21,8 @@ public static class MauiProgram
                 {
                     fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
                     fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
-                });
+                })
+                .AddRaygun4Maui("<YOUR_API_KEY_HERE>");
 #if DEBUG
         builder.Logging.AddDebug();
 #endif


### PR DESCRIPTION
# Added raygun crashreporting automatically using AI magic ✨. 
 # There are a number of things to note before merging: 
 - [ ] Triple check this code, it could very well be wrong and could break your application. 
 - [ ] You will need to install the appropriate raygun package in order for this to work 
 # AI Notes 
 - You can install the Raygun4Maui package from NuGet to use Raygun Crash Reporting in your Maui project.