### PR TITLE
Add raygun crashreporting

### DIFF
--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -1,30 +1,32 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Configuration;
+using Raygun4Maui;
 
-namespace mauitests;
-
-public static class MauiProgram
+namespace mauitests
 {
-    public static MauiApp CreateMauiApp()
+    public static class MauiProgram
     {
+        public static MauiApp CreateMauiApp()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddUserSecrets<MainPage>()
+                .Build();
 
-        var configuration = new ConfigurationBuilder()
-       .AddUserSecrets<MainPage>()
-       .Build();
-
-
-        var builder = MauiApp.CreateBuilder();
-        builder
+            var builder = MauiApp.CreateBuilder();
+            builder
                 .UseMauiApp<App>()
                 .ConfigureFonts(fonts =>
                 {
                     fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
                     fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
-                });
+                })
+                .AddRaygun4Maui("<YOUR_API_KEY_HERE>")
 #if DEBUG
-        builder.Logging.AddDebug();
+                .Logging.AddDebug()
 #endif
+                ;
 
-        return builder.Build();
+            return builder.Build();
+        }
     }
 }


### PR DESCRIPTION
# Added raygun crashreporting automatically using AI magic ✨. 
 # There are a number of things to note before merging: 
 - [ ] Triple check this code, it could very well be wrong and could break your application. 
 - [ ] You will need to install the appropriate raygun package in order for this to work 
 # AI Notes 
 - You can install the Raygun4Maui NuGet package to make this work. You can use the NuGet package manager to search for and install Raygun4Maui or use the .NET CLI to install the latest version or specify a version tag to install a specific version of the package.