### PR TITLE
Add raygun crashreporting

### DIFF
--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Configuration;
+using Raygun4Maui;
 
 namespace mauitests;
 
@@ -24,6 +25,12 @@ public static class MauiProgram
 #if DEBUG
         builder.Logging.AddDebug();
 #endif
+
+        // Add Raygun4Maui module with API key
+        builder.Services.AddRaygun4Maui(options =>
+        {
+            options.ApiKey = "YOUR_API_KEY_HERE";
+        });
 
         return builder.Build();
     }


### PR DESCRIPTION
# Added raygun crashreporting automatically using AI magic ✨. 
 # There are a number of things to note before merging: 
 - [ ] Triple check this code, it could very well be wrong and could break your application. 
 - [ ] You will need to install the appropriate raygun package in order for this to work 
 # AI Notes 
 - You should use the Mindscape.Raygun4Net package to make Raygun Crash Reporting work in .NET MAUI.