### PR TITLE
Add raygun crashreporting

### DIFF
--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -1,30 +1,34 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Configuration;
+using Raygun4Maui;
 
-namespace mauitests;
-
-public static class MauiProgram
+namespace mauitests
 {
-    public static MauiApp CreateMauiApp()
+    public static class MauiProgram
     {
+        public static MauiApp CreateMauiApp()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddUserSecrets<MainPage>()
+                .Build();
 
-        var configuration = new ConfigurationBuilder()
-       .AddUserSecrets<MainPage>()
-       .Build();
-
-
-        var builder = MauiApp.CreateBuilder();
-        builder
+            var builder = MauiApp.CreateBuilder();
+            builder
                 .UseMauiApp<App>()
                 .ConfigureFonts(fonts =>
                 {
                     fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
                     fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
+                })
+                .ConfigureServices(services =>
+                {
+                    services.AddRaygun();
                 });
 #if DEBUG
-        builder.Logging.AddDebug();
+            builder.Logging.AddDebug();
 #endif
 
-        return builder.Build();
+            return builder.Build();
+        }
     }
 }


### PR DESCRIPTION
# Added raygun crashreporting automatically using AI magic ✨. 
 # There are a number of things to note before merging: 
 - [ ] Triple check this code, it could very well be wrong and could break your application. 
 - [ ] You will need to install the appropriate raygun package in order for this to work 
 # AI Notes 
 - To make this work, you should install the `Mindscape.Raygun4Net.Maui` NuGet package. This package contains the Raygun4Maui module that is needed to integrate Raygun Crash Reporting into a .NET MAUI 6.0 project.