### PR TITLE
Add raygun crashreporting

### DIFF
--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -1,30 +1,32 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Configuration;
+using Raygun.Maui;
 
-namespace mauitests;
-
-public static class MauiProgram
+namespace mauitests
 {
-    public static MauiApp CreateMauiApp()
+    public static class MauiProgram
     {
+        public static MauiApp CreateMauiApp()
+        {
+            var configuration = new ConfigurationBuilder()
+                .AddUserSecrets<MainPage>()
+                .Build();
 
-        var configuration = new ConfigurationBuilder()
-       .AddUserSecrets<MainPage>()
-       .Build();
-
-
-        var builder = MauiApp.CreateBuilder();
-        builder
+            var builder = MauiApp.CreateBuilder();
+            builder
                 .UseMauiApp<App>()
                 .ConfigureFonts(fonts =>
                 {
                     fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
                     fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
-                });
+                })
+                .UseRaygunCrashReporting("<YOUR_RAYGUN_API_KEY>");
+
 #if DEBUG
-        builder.Logging.AddDebug();
+            builder.Logging.AddDebug();
 #endif
 
-        return builder.Build();
+            return builder.Build();
+        }
     }
 }


### PR DESCRIPTION
# Added raygun crashreporting automatically using AI magic ✨. 
 # There are a number of things to note before merging: 
 - [ ] Triple check this code, it could very well be wrong and could break your application. 
 - [ ] You will need to install the appropriate raygun package in order for this to work 
 # AI Notes 
 - You should install the `Raygun.Maui` package to make this work. You can do this by running the following command in the Package Manager Console:

```
Install-Package Raygun.Maui
``` 

Or by adding the following line to your project file:

```
<PackageReference Include="Raygun.Maui" Version="1.0.0" />
``` 

Make sure to replace the version number with the latest version available.