### PR TITLE
Add raygun crashreporting

### DIFF
--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -1,5 +1,6 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Configuration;
+using Raygun4Maui;
 
 namespace mauitests;
 
@@ -24,6 +25,8 @@ public static class MauiProgram
 #if DEBUG
         builder.Logging.AddDebug();
 #endif
+
+        builder.AddRaygun4Maui(configuration.GetSection("RaygunSettings"));
 
         return builder.Build();
     }


### PR DESCRIPTION
# Added raygun crashreporting automatically using AI magic ✨. 
 # There are a number of things to note before merging: 
 - [ ] Triple check this code, it could very well be wrong and could break your application. 
 - [ ] You will need to install the appropriate raygun package in order for this to work 
 # AI Notes 
 - You should install the `Raygun4Maui` NuGet package to make this work. You can use the following command in the NuGet Package Manager Console to install it:

```
Install-Package Raygun4Maui
```