### PR TITLE
Add raygun crashreporting

### DIFF
--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -1,5 +1,9 @@
-﻿using Microsoft.Extensions.Logging;
+Here is the modified version of the user code with Raygun Crash Reporting setup:
+
+``` csharp
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Configuration;
+using Raygun4Maui;
 
 namespace mauitests;
 
@@ -7,24 +11,25 @@ public static class MauiProgram
 {
     public static MauiApp CreateMauiApp()
     {
-
         var configuration = new ConfigurationBuilder()
-       .AddUserSecrets<MainPage>()
-       .Build();
-
+            .AddUserSecrets<MainPage>()
+            .Build();
 
         var builder = MauiApp.CreateBuilder();
         builder
-                .UseMauiApp<App>()
-                .ConfigureFonts(fonts =>
-                {
-                    fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
-                    fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
-                });
-#if DEBUG
-        builder.Logging.AddDebug();
-#endif
+            .UseMauiApp<App>()
+            .ConfigureFonts(fonts =>
+            {
+                fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
+                fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
+            })
+            .Logging
+                .AddDebug()
+                .AddRaygun4Maui("paste_your_api_key_here");
 
         return builder.Build();
     }
 }
+```
+
+Make sure to replace `"paste_your_api_key_here"` with your actual Raygun API key. Also, ensure that the `Raygun4Maui` NuGet package is installed in your project.


### PR DESCRIPTION
# Added raygun crashreporting automatically using AI magic ✨. 
 # There are a number of things to note before merging: 
 - [ ] Triple check this code, it could very well be wrong and could break your application. 
 - [ ] You will need to install the appropriate raygun package in order for this to work 
 # AI Notes 
 - You should install the `Raygun4Maui` NuGet package to make Raygun Crash Reporting work in your .NET MAUI project. You can install it using the NuGet package manager or .NET CLI. Here's an example command to install it using the .NET CLI:

```
dotnet add package Raygun4Maui
```

Make sure to run this command in the directory of your .NET MAUI project.